### PR TITLE
Provide a runnable main method

### DIFF
--- a/solution.py
+++ b/solution.py
@@ -1,8 +1,37 @@
+import signal
+import sys
+
+import solver
+import solution_graph
+
+# A global flag for whether the program should stop executing
+SHOULD_STOP = False
+
+def _sigint_handler(sig, frame):
+  global SHOULD_STOP
+  print('SIGINT caught. Finishing up.')
+  SHOULD_STOP = True
+
+def display_solution(solution_graph: solution_graph.SolutionGraph):
+  print(solution_graph)
+
 def main():
   """
   Runs the solution code.
   """
-  raise NotImplementedError("Work in progress")
+  my_solver = solver.Solver()
+  my_solution_graph = solution_graph.SolutionGraph()
+  my_solver.solution_graph = my_solution_graph
+
+  # Catch SIGINT
+  signal.signal(signal.SIGINT, _sigint_handler)
+
+  while (not my_solver.solution_found and not SHOULD_STOP):
+    my_solver.step()
+  # On loop end or SIGINT, display solution
+  display_solution(my_solution_graph)
+
+  sys.exit(0)
 
 if __name__ == "__main__":
   main()

--- a/solution_graph.py
+++ b/solution_graph.py
@@ -1,0 +1,3 @@
+class SolutionGraph:
+  def __str__(self):
+    return 'Printing SolutionGraph is WIP'

--- a/solver.py
+++ b/solver.py
@@ -1,0 +1,9 @@
+import time
+
+class Solver:
+  solution_graph = None
+  solution_found = False
+
+  def step(self):
+    print('Solver taking a step')
+    time.sleep(1)


### PR DESCRIPTION
As of this commit, `python3 solution.py` will simulate a solver taking a
step every 1s. Users can send `SIGINT` to interrupt the solver, at which
point it will exit gracefully.

Placeholders for solution-related data structures are provided.

Issue: #3